### PR TITLE
Support signature scheme id versioning and user billing (direct funding and subscriptions)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "devDependencies": {
         "@commitlint/cli": "^19.2.1",
         "@commitlint/config-conventional": "^19.1.0",
-        "@noble/curves": "^1.6.0",
+        "@noble/curves": "1.6.0",
         "@nomicfoundation/ethereumjs-util": "^9.0.4",
         "@nomicfoundation/hardhat-foundry": "^1.1.2",
         "@nomicfoundation/hardhat-toolbox": "^5.0.0",

--- a/script/libraries/Constants.sol
+++ b/script/libraries/Constants.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8;
 
 library Constants {
-    bytes32 constant SALT = bytes32(uint256(26));
+    bytes32 constant SALT = bytes32(uint256(28));
 
     string constant RANDOMNESS_BN254_SIGNATURE_SCHEME_ID = "BN254";
     string constant DEPLOYMENT_INPUT_JSON_PATH = "Deployment_input.json";

--- a/script/single-deployment/DeployRandomnessSender.s.sol
+++ b/script/single-deployment/DeployRandomnessSender.s.sol
@@ -41,6 +41,9 @@ contract DeployRandomnessSender is JsonUtils, EnvReader {
             RandomnessSender(proxyAddress).upgradeToAndCall(implementation, "");
             console.log("RandomnessSender contract upgraded to new implementation at: ", implementation);
             randomnessSenderInstance = RandomnessSender(proxyAddress);
+
+            vm.broadcast();
+            randomnessSenderInstance.setSignatureSender(signatureSenderProxyAddress);
         } else {
             // Deploy a new proxy if it's a full deployment
             bytes memory code = abi.encodePacked(type(UUPSProxy).creationCode, abi.encode(implementation, ""));

--- a/script/single-deployment/DeploySignatureSender.s.sol
+++ b/script/single-deployment/DeploySignatureSender.s.sol
@@ -64,9 +64,7 @@ contract DeploySignatureSender is JsonUtils, EnvReader {
             );
 
             vm.broadcast();
-            signatureSenderInstance.initialize(
-                getBLSPublicKey().x, getBLSPublicKey().y, getSignerAddress(), signatureSchemeAddressProviderAddress
-            );
+            signatureSenderInstance.initialize(getSignerAddress(), signatureSchemeAddressProviderAddress);
 
             console.log("SignatureSender proxy contract deployed at: ", contractAddress);
         }

--- a/src/interfaces/ISignatureScheme.sol
+++ b/src/interfaces/ISignatureScheme.sol
@@ -5,8 +5,14 @@ pragma solidity ^0.8;
 /// @author Randamu
 /// @notice Interface for signature schemes, e.g., BN254, BLS, etc.
 interface ISignatureScheme {
-    /// @notice Returns the scheme identifier as a string, e.g., "BN254", "BLS12-381", "TESS"
-    function SCHEME_ID() external returns (string memory);
+    /// @notice Returns the scheme identifier as a string, e.g., "Barreto-Naehrig Curve" or "BN254"
+    /// BN254 is an elliptic curve that belongs to the pairing-friendly curves family,
+    /// designed for efficient computation of pairing-based cryptographic
+    /// protocols (such as zk-SNARKs, zero-knowledge proofs, and other cryptographic constructions)
+    function SCHEME_ID() external view returns (string memory);
+
+    /// @notice returns the DST used in message hashing to BLS point
+    function DST() external view returns (bytes memory);
 
     /// @notice Verifies a signature using the given signature scheme.
     /// @param message The message that was signed. Message is a G1 point represented as bytes.
@@ -27,6 +33,16 @@ interface ISignatureScheme {
     /// @param message The message to be hashed.
     /// @return bytes A point on the elliptic curve in G1, represented as bytes.
     function hashToBytes(bytes calldata message) external view returns (bytes memory);
+
+    /// @notice Retrieves the public key associated with the decryption process.
+    /// @dev Returns the public key as two elliptic curve points.
+    /// @return Two pairs of coordinates representing the public key points on the elliptic curve.
+    function getPublicKey() external view returns (uint256[2] memory, uint256[2] memory);
+
+    /// @notice Retrieves the public key associated with the decryption process.
+    /// @dev Returns the public key as bytes.
+    /// @return Bytes string representing the public key points on the elliptic curve.
+    function getPublicKeyBytes() external view returns (bytes memory);
 
     /// @notice Returns the current blockchain chain ID.
     /// @dev Uses inline assembly to retrieve the `chainid` opcode.

--- a/src/interfaces/ISignatureSender.sol
+++ b/src/interfaces/ISignatureSender.sol
@@ -3,10 +3,15 @@ pragma solidity ^0.8;
 
 import "../libraries/TypesLib.sol";
 
+import {ISignatureSchemeAddressProvider} from "./ISignatureSchemeAddressProvider.sol";
+
 /// @title ISignatureSender interface
 /// @author Randamu
 /// @notice Enables signature requests and callbacks
 interface ISignatureSender {
+    /// @notice Returns the signature scheme address provider contract
+    function signatureSchemeAddressProvider() external view returns (ISignatureSchemeAddressProvider);
+
     /// @notice Requests a digital signature for a given message using a specified signature scheme.
     /// @dev Initiates a request for signing the provided `message` under the specified `schemeID`.
     /// @param schemeID The identifier of the signature scheme to be used.
@@ -21,7 +26,7 @@ interface ISignatureSender {
     /// @dev Completes the signing process for the request identified by `requestID`.
     /// @param requestID The unique identifier of the signature request being fulfilled.
     /// @param signature The generated signature, provided as a byte array.
-    function fulfilSignatureRequest(uint256 requestID, bytes calldata signature) external;
+    function fulfillSignatureRequest(uint256 requestID, bytes calldata signature) external;
 
     /// @notice Retries a request that previously failed during callback.
     /// @dev This function is called if a signature was generated off-chain but failed to call back into the contract.
@@ -47,16 +52,6 @@ interface ISignatureSender {
     /// @param requestID The ID of the request to check.
     /// @return Boolean indicating whether the request has errored or not.
     function hasErrored(uint256 requestID) external view returns (bool);
-
-    /// @notice Retrieves the public key associated with the signature process.
-    /// @dev Returns the public key as two elliptic curve points.
-    /// @return Two pairs of coordinates representing the public key points on the elliptic curve.
-    function getPublicKey() external view returns (uint256[2] memory, uint256[2] memory);
-
-    /// @notice Retrieves the public key associated with the signature process.
-    /// @dev Returns the public key as bytes.
-    /// @return Bytes string representing the public key points on the elliptic curve.
-    function getPublicKeyBytes() external view returns (bytes memory);
 
     /// @notice Returns all the fulfilled request IDs.
     /// @return A uint array representing a set containing all fulfilled request IDs.

--- a/src/libraries/BytesLib.sol
+++ b/src/libraries/BytesLib.sol
@@ -48,4 +48,18 @@ library BytesLib {
         require(data.length >= 32, "Data must be at least 32 bytes long");
         return abi.decode(data, (uint256)); // Decode bytes back to uint
     }
+
+    /// @dev Converts bytes32 to 0x-prefixed hex string.
+    /// @param data The bytes32 data to convert.
+    function toHexString(bytes32 data) internal pure returns (string memory) {
+        bytes memory hexChars = "0123456789abcdef";
+        bytes memory str = new bytes(2 + 64); // "0x" + 64 hex chars
+        str[0] = "0";
+        str[1] = "x";
+        for (uint256 i = 0; i < 32; i++) {
+            str[2 + i * 2] = hexChars[uint8(data[i] >> 4)];
+            str[2 + i * 2 + 1] = hexChars[uint8(data[i] & 0x0f)];
+        }
+        return string(str);
+    }
 }

--- a/src/randomness/Randomness.sol
+++ b/src/randomness/Randomness.sol
@@ -2,12 +2,15 @@
 pragma solidity ^0.8;
 
 import {BLS} from "../libraries/BLS.sol";
-import {FeistelShuffleOptimised} from "./FeistelShuffleOptimised.sol";
+import {TypesLib} from "../libraries/TypesLib.sol";
+
 import {IRandomnessSender} from "../interfaces/IRandomnessSender.sol";
 import {ISignatureSender} from "../interfaces/ISignatureSender.sol";
+import {ISignatureScheme} from "../interfaces/ISignatureScheme.sol";
+import {ISignatureSchemeAddressProvider} from "../interfaces/ISignatureSchemeAddressProvider.sol";
+
 import {RandomnessSender} from "./RandomnessSender.sol";
-import {TypesLib} from "../libraries/TypesLib.sol";
-import {SignatureSender} from "../signature-requests/SignatureSender.sol";
+import {FeistelShuffleOptimised} from "./FeistelShuffleOptimised.sol";
 
 /// @title Randomness library contract
 /// @author Randamu
@@ -18,6 +21,51 @@ library Randomness {
         return randomnessContract.requestRandomness();
     }
 
+    // /// @notice Verify randomness received from offchain threshold network.
+    // function verify(
+    //     address randomnessContract,
+    //     address signatureContract,
+    //     bytes calldata signature,
+    //     uint256 requestID,
+    //     address requester,
+    //     bytes calldata DST
+    // ) public view returns (bool) {
+    //     (uint256[2] memory x, uint256[2] memory y) = ISignatureSender(signatureContract).getPublicKey();
+    //     BLS.PointG2 memory pk = BLS.PointG2({x: x, y: y});
+    //     BLS.PointG1 memory _message = BLS.hashToPoint(
+    //         DST, IRandomnessSender(randomnessContract).messageFrom(TypesLib.RandomnessRequest(requestID, requester))
+    //     );
+    //     BLS.PointG1 memory _signature = BLS.g1Unmarshal(signature);
+    //     (bool pairingSuccess, bool callSuccess) = BLS.verifySingle(_signature, pk, _message);
+    //     return pairingSuccess && callSuccess;
+    // }
+
+    // /// @notice Verify randomness received from offchain threshold network.
+    // function verify(
+    //     address randomnessContract,
+    //     address signatureContract,
+    //     bytes calldata signature,
+    //     uint256 requestID,
+    //     address requester
+    // ) public view returns (bool) {
+    //     ISignatureSender sigSender = ISignatureSender(signatureContract);
+
+    //     // Fetch request data and public key
+    //     string memory schemeID = sigSender.getRequest(requestID).schemeID;
+    //     ISignatureScheme sigScheme = _getSignatureScheme(sigSender, schemeID);
+    //     BLS.PointG2 memory pk = _getPublicKey(sigScheme);
+
+    //     // Prepare message and signature
+    //     bytes memory messageData = IRandomnessSender(randomnessContract).messageFrom(
+    //         TypesLib.RandomnessRequest(requestID, requester)
+    //     );
+    //     BLS.PointG1 memory _message = BLS.hashToPoint(sigScheme.DST(), messageData);
+    //     BLS.PointG1 memory _signature = BLS.g1Unmarshal(signature);
+
+    //     // Verify signature
+    //     (bool pairingSuccess, bool callSuccess) = BLS.verifySingle(_signature, pk, _message);
+    //     return pairingSuccess && callSuccess;
+    // }
     /// @notice Verify randomness received from offchain threshold network.
     function verify(
         address randomnessContract,
@@ -25,16 +73,24 @@ library Randomness {
         bytes calldata signature,
         uint256 requestID,
         address requester,
-        bytes calldata DST
+        string calldata schemeID
     ) public view returns (bool) {
-        (uint256[2] memory x, uint256[2] memory y) = ISignatureSender(signatureContract).getPublicKey();
-        BLS.PointG2 memory pk = BLS.PointG2({x: x, y: y});
-        BLS.PointG1 memory _message = BLS.hashToPoint(
-            DST, IRandomnessSender(randomnessContract).messageFrom(TypesLib.RandomnessRequest(requestID, requester))
+        ISignatureSender signatureSender = ISignatureSender(signatureContract);
+        ISignatureSchemeAddressProvider signatureSchemeAddressProvider =
+            signatureSender.signatureSchemeAddressProvider();
+        ISignatureScheme signatureScheme =
+            ISignatureScheme(signatureSchemeAddressProvider.getSignatureSchemeAddress(schemeID));
+
+        BLS.PointG1 memory messageHash = BLS.hashToPoint(
+            signatureScheme.DST(),
+            IRandomnessSender(randomnessContract).messageFrom(TypesLib.RandomnessRequest(requestID, requester))
         );
         BLS.PointG1 memory _signature = BLS.g1Unmarshal(signature);
-        (bool pairingSuccess, bool callSuccess) = BLS.verifySingle(_signature, pk, _message);
-        return pairingSuccess && callSuccess;
+
+        bool pairingSuccess = signatureScheme.verifySignature(
+            BLS.g1Marshal(messageHash), BLS.g1Marshal(_signature), signatureScheme.getPublicKeyBytes()
+        );
+        return pairingSuccess;
     }
 
     /// @notice Select array indices randomly

--- a/src/signature-schemes/SignatureSchemeBase.sol
+++ b/src/signature-schemes/SignatureSchemeBase.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8;
+
+import {BLS} from "../libraries/BLS.sol";
+
+import {ISignatureScheme} from "../interfaces/ISignatureScheme.sol";
+
+/// @title SignatureSchemeBase contract
+/// @author Randamu
+/// @notice Base contract that all signature scheme contracts must implement.
+abstract contract SignatureSchemeBase is ISignatureScheme {
+    /// @notice Links public keys of threshold network statically to signature scheme contracts and remove from constructor of sender contracts. Admin cannot update, simply use new scheme id.
+    BLS.PointG2 private publicKey = BLS.PointG2({x: [uint256(0), uint256(0)], y: [uint256(0), uint256(0)]});
+
+    constructor(uint256[2] memory x, uint256[2] memory y) {
+        publicKey = BLS.PointG2({x: x, y: y});
+    }
+
+    /// @notice Retrieves the public key associated with the decryption process.
+    /// @dev Returns the public key as two elliptic curve points.
+    /// @return Two pairs of coordinates representing the public key points on the elliptic curve.
+    function getPublicKey() public view returns (uint256[2] memory, uint256[2] memory) {
+        return (publicKey.x, publicKey.y);
+    }
+
+    /// @notice Retrieves the public key associated with the decryption process.
+    /// @dev Returns the public key as bytes.
+    /// @return Bytes string representing the public key points on the elliptic curve.
+    function getPublicKeyBytes() public view returns (bytes memory) {
+        return BLS.g2Marshal(publicKey);
+    }
+
+    /// @notice Returns the current blockchain chain ID.
+    /// @dev Uses inline assembly to retrieve the `chainid` opcode.
+    /// @return chainId The current chain ID of the network.
+    function getChainId() public view returns (uint256 chainId) {
+        assembly {
+            chainId := chainid()
+        }
+    }
+}


### PR DESCRIPTION
Tasks
- [x] Move bls public key to signature scheme contracts to prevent signature sender being tied to a single scheme and to allow signature scheme versioning
- [ ] Add user billing logic for direct funding and subscription funding