### PR TITLE
fix(ci): no unlocked dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       
-      - name: Install hardhat
+      - name: Install Hardhat
         run: |
-          yarn add --dev hardhat
+          npm install
         id: hardhat-install
 
       - name: Show Forge version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "randomness-solidity",
-    "version": "0.0.2",
+    "version": "0.0.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "randomness-solidity",
-            "version": "0.0.2",
+            "version": "0.0.7",
             "license": "MIT",
             "dependencies": {
                 "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",


### PR DESCRIPTION
Using yarn prints the following warning:

```
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn.
```

When hardhat 3.0 came out, the CI switched to it immediately and broke.